### PR TITLE
Fix for strict mode

### DIFF
--- a/lib/bcrypt.js
+++ b/lib/bcrypt.js
@@ -255,7 +255,7 @@ exports.BCrypt.prototype.hash = function(password, salt) {
   var rounds = this.iterationCountLog2;
   var rs = [];
   
-  password += '\000';
+  password += minor;
   for (var r = 0; r < password.length; r++)
     passwordb.push(utils.getByte(password.charAt(r)));
   


### PR DESCRIPTION
Strict mode doesn't allow octal literals.

`minor` is defined but never used, I'm assuming it was meant for this and was just overlooked.
